### PR TITLE
feat: make application name dynamic

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -39,6 +39,7 @@ final class HandleInertiaRequests extends Middleware
     {
         /** @var array<string, mixed> */
         return array_merge(parent::share($request), [
+            'name' => config('app.name', 'Larasonic'),
             'flash' => [
                 'message' => fn () => $request->session()->get('message'),
                 'success' => fn () => $request->session()->get('success'),

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -6,6 +6,7 @@ namespace App\Http\Middleware;
 
 use Inertia\Middleware;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
 
 final class HandleInertiaRequests extends Middleware
 {
@@ -39,7 +40,7 @@ final class HandleInertiaRequests extends Middleware
     {
         /** @var array<string, mixed> */
         return array_merge(parent::share($request), [
-            'name' => config('app.name', 'Larasonic'),
+            'name' => Config::get('app.name', 'Larasonic'),
             'flash' => [
                 'message' => fn () => $request->session()->get('message'),
                 'success' => fn () => $request->session()->get('success'),

--- a/resources/js/Layouts/WebLayout.vue
+++ b/resources/js/Layouts/WebLayout.vue
@@ -45,9 +45,11 @@ function toggleMenu() {
     >
       <div class="container flex h-16 items-center justify-between">
         <div class="flex items-center">
-          <a class="flex items-center space-x-2" href="/" aria-label="Larasonic">
+          <a class="flex items-center space-x-2" href="/" :aria-label="$page.props.name">
             <Icon icon="lucide:rocket" class="h-6 w-6" aria-hidden="true" />
-            <span class="hidden font-bold sm:inline-block">Larasonic</span>
+            <span class="hidden font-bold sm:inline-block">
+                {{ $page.props.name }}
+            </span>
           </a>
           <nav class="hidden md:flex items-center space-x-6 text-sm font-medium sm:ml-4">
             <a

--- a/resources/js/Pages/Chat/Index.vue
+++ b/resources/js/Pages/Chat/Index.vue
@@ -16,6 +16,7 @@ import { inject, onMounted, ref } from 'vue'
 import { toast } from 'vue-sonner'
 import ModelSelector from './Components/ModelSelector.vue'
 import TemperatureSelector from './Components/TemperatureSelector.vue'
+
 const props = defineProps({
   systemPrompt: String,
   models: Array,

--- a/resources/js/Pages/Chat/Index.vue
+++ b/resources/js/Pages/Chat/Index.vue
@@ -10,13 +10,12 @@ import Skeleton from '@/Components/shadcn/ui/skeleton/Skeleton.vue'
 import { Textarea } from '@/Components/shadcn/ui/textarea'
 import AppLayout from '@/Layouts/AppLayout.vue'
 import { Icon } from '@iconify/vue'
-import { router } from '@inertiajs/vue3'
+import { router, usePage } from '@inertiajs/vue3'
 import { useFetch } from '@vueuse/core'
 import { inject, onMounted, ref } from 'vue'
 import { toast } from 'vue-sonner'
 import ModelSelector from './Components/ModelSelector.vue'
 import TemperatureSelector from './Components/TemperatureSelector.vue'
-
 const props = defineProps({
   systemPrompt: String,
   models: Array,
@@ -79,13 +78,15 @@ onMounted(() => {
     })
   }
 })
+
+const title = `${usePage().props.name} - AI Playground`
 </script>
 
 <template>
-  <AppLayout title="Larasonic AI Playground">
+  <AppLayout :title="title">
     <template #header>
       <h2 class="text-xl font-semibold leading-tight">
-        Larasonic AI Playground
+        {{ $page.props.name }} AI Playground
       </h2>
     </template>
     <div class="h-full flex-col flex">


### PR DESCRIPTION
This pull request includes changes to update the application name dynamically based on configuration settings. The most important changes involve updating the application name in various parts of the codebase to use a dynamic value instead of a hardcoded string.

Dynamic application name updates:

* [`app/Http/Middleware/HandleInertiaRequests.php`](diffhunk://#diff-83c0cdfc438586e614726fc44d098cd76e7605af4f067c21ceaaecae6e2051d1R42): Added a new entry `'name'` to the shared data, which retrieves the application name from the configuration.
* [`resources/js/Layouts/WebLayout.vue`](diffhunk://#diff-15567918ba1e267e6df93c2731c6c99fd9497e0e4e6070c08a0cee2145b88ac6L48-R52): Updated the `aria-label` and displayed text for the application name to use the dynamic value from `$page.props.name`.
* [`resources/js/Pages/Chat/Index.vue`](diffhunk://#diff-e5ae71058f1461eb1a804241e4c516545e0ba3e1827014f7dee0826f47b769bbL13-L19): Imported `usePage` from `@inertiajs/vue3` and used it to dynamically set the page title and header text with the application name. [[1]](diffhunk://#diff-e5ae71058f1461eb1a804241e4c516545e0ba3e1827014f7dee0826f47b769bbL13-L19) [[2]](diffhunk://#diff-e5ae71058f1461eb1a804241e4c516545e0ba3e1827014f7dee0826f47b769bbR81-R89)nstead of storing Larasonic as plain text in the Vue template, let's grab the text from the `.env` file