### PR TITLE
fix: typo in github link

### DIFF
--- a/resources/js/Layouts/WebLayout.vue
+++ b/resources/js/Layouts/WebLayout.vue
@@ -75,7 +75,10 @@ function toggleMenu() {
               Dashboard
             </Button>
           </div>
-          <Button variant="ghost" size="icon" aria-label="Toggle Theme" @click="mode = mode === 'dark' ? 'light' : 'dark'">
+          <Button
+            variant="ghost" size="icon" aria-label="Toggle Theme"
+            @click="mode = mode === 'dark' ? 'light' : 'dark'"
+          >
             <Icon
               class="text-muted-foreground h-6 w-6"
               :icon="mode === 'dark' ? 'lucide:sun' : 'lucide:moon'"
@@ -118,7 +121,7 @@ function toggleMenu() {
             Dashboard
           </Button>
           <a
-            href="https://github.com/pushpak1300/larasonic/" target="_blank" rel="noreferrer"
+            :href="githubUrl" target="_blank" rel="noreferrer"
             class="flex items-center space-x-2 text-sm font-medium" @click="toggleMobileMenu"
           >
             <Icon icon="mdi:github" class="h-5 w-5" />

--- a/resources/js/Layouts/WebLayout.vue
+++ b/resources/js/Layouts/WebLayout.vue
@@ -118,7 +118,7 @@ function toggleMenu() {
             Dashboard
           </Button>
           <a
-            href="https://github.com/your-repo" target="_blank" rel="noreferrer"
+            href="https://github.com/pushpak1300/larasonic/" target="_blank" rel="noreferrer"
             class="flex items-center space-x-2 text-sm font-medium" @click="toggleMobileMenu"
           >
             <Icon icon="mdi:github" class="h-5 w-5" />


### PR DESCRIPTION
This pull request includes a small change to the `resources/js/Layouts/WebLayout.vue` file. The change updates the GitHub repository link in the `toggleMenu` function.

* [`resources/js/Layouts/WebLayout.vue`](diffhunk://#diff-15567918ba1e267e6df93c2731c6c99fd9497e0e4e6070c08a0cee2145b88ac6L121-R121): Updated the GitHub repository link from `https://github.com/your-repo` to `https://github.com/pushpak1300/larasonic/`.